### PR TITLE
fix(widget): update schedule widget

### DIFF
--- a/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetScheduler.kt
+++ b/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetScheduler.kt
@@ -4,16 +4,13 @@ import android.content.Context
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import lamdx4.uis.ptithcm.util.calculateInitialDelay
 import java.util.concurrent.TimeUnit
 
 fun scheduleDailyWidgetUpdate(context: Context) {
-    val delay = calculateInitialDelay() // tính số ms từ bây giờ đến 0h hôm sau
 
     val workRequest = PeriodicWorkRequestBuilder<WidgetUpdateWorker>(
         4, TimeUnit.HOURS // lặp lại mỗi 4 giờ
     )
-        .setInitialDelay(delay, TimeUnit.MILLISECONDS) // lần đầu chạy sau delay
         .build()
 
     WorkManager.getInstance(context).enqueueUniquePeriodicWork(

--- a/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetScheduler.kt
+++ b/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetScheduler.kt
@@ -11,7 +11,7 @@ fun scheduleDailyWidgetUpdate(context: Context) {
     val delay = calculateInitialDelay() // tính số ms từ bây giờ đến 0h hôm sau
 
     val workRequest = PeriodicWorkRequestBuilder<WidgetUpdateWorker>(
-        1, TimeUnit.DAYS // lặp lại mỗi 1 ngày
+        4, TimeUnit.HOURS // lặp lại mỗi 4 giờ
     )
         .setInitialDelay(delay, TimeUnit.MILLISECONDS) // lần đầu chạy sau delay
         .build()

--- a/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetUpdateWorker.kt
+++ b/app/src/main/java/lamdx4/uis/ptithcm/service/WidgetUpdateWorker.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.glance.appwidget.updateAll
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import dagger.hilt.android.EntryPointAccessors
-import lamdx4.uis.ptithcm.ui.widget.ScheduleRepositoryEntryPoint
 import lamdx4.uis.ptithcm.ui.widget.ScheduleWidget
 
 class WidgetUpdateWorker(
@@ -15,18 +13,19 @@ class WidgetUpdateWorker(
 
     override suspend fun doWork(): Result {
         return try {
-            // Lấy repository từ Hilt
-            val entryPoint = EntryPointAccessors.fromApplication(
-                context,
-                ScheduleRepositoryEntryPoint::class.java
-            )
-            val scheduleRepository = entryPoint.getScheduleRepository()
-
-            // Gọi API lấy học kỳ và lưu DB
-            val semesterCode = scheduleRepository.getCurrentSemester()?.semesterCode
-            if (semesterCode != null) {
-                scheduleRepository.saveWeeklySchedule(semesterCode)
-            }
+            // refresh token lifetime is too short
+//            // Lấy repository từ Hilt
+//            val entryPoint = EntryPointAccessors.fromApplication(
+//                context,
+//                ScheduleRepositoryEntryPoint::class.java
+//            )
+//            val scheduleRepository = entryPoint.getScheduleRepository()
+//
+//            // Gọi API lấy học kỳ và lưu DB
+//            val semesterCode = scheduleRepository.getCurrentSemester()?.semesterCode
+//            if (semesterCode != null) {
+//                scheduleRepository.saveWeeklySchedule(semesterCode)
+//            }
 
             // Cập nhật widget
             ScheduleWidget().updateAll(context)

--- a/app/src/main/java/lamdx4/uis/ptithcm/ui/widget/ScheduleWidget.kt
+++ b/app/src/main/java/lamdx4/uis/ptithcm/ui/widget/ScheduleWidget.kt
@@ -31,6 +31,7 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import lamdx4.uis.ptithcm.data.repository.ScheduleRepository
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -43,7 +44,8 @@ class ScheduleWidget() : GlanceAppWidget() {
         )
         val scheduleRepository = entryPoint.getScheduleRepository()
 
-        val today = LocalDate.now()
+        val zoneVN = ZoneId.of("Asia/Ho_Chi_Minh")
+        val today = LocalDate.now(zoneVN)
         val formatter = DateTimeFormatter.ofPattern("EEEE, dd/MM/yyyy", Locale("vi", "VN"))
         val showedDate = today.format(formatter).replaceFirstChar { it.uppercaseChar() }
 
@@ -193,17 +195,19 @@ class RefreshActionCallback : ActionCallback {
         glanceId: GlanceId,
         parameters: ActionParameters
     ) {
-        val entryPoint = EntryPointAccessors.fromApplication(
-            context,
-            ScheduleRepositoryEntryPoint::class.java
-        )
-        val scheduleRepository = entryPoint.getScheduleRepository()
+        // refresh token lifetime is too short
+//        val entryPoint = EntryPointAccessors.fromApplication(
+//            context,
+//            ScheduleRepositoryEntryPoint::class.java
+//        )
+//        val scheduleRepository = entryPoint.getScheduleRepository()
+//
+//        // Fetch and save weekly schedule to database
+//        val semesterCode = scheduleRepository.getCurrentSemester()?.semesterCode
+//        if (semesterCode != null) {
+//            scheduleRepository.saveWeeklySchedule(semesterCode)
+//        }
 
-        // Fetch and save weekly schedule to database
-        val semesterCode = scheduleRepository.getCurrentSemester()?.semesterCode
-        if (semesterCode != null) {
-            scheduleRepository.saveWeeklySchedule(semesterCode)
-        }
         ScheduleWidget().update(context, glanceId)
     }
 }


### PR DESCRIPTION
Change widget update interval to 4 hours.
Disable automatic data fetching in the background due to a short refresh token lifetime, just update UI using data from room. Set the time zone to "Asia/Ho_Chi_Minh" for displaying the date in the widget.